### PR TITLE
Delete dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: monthly
-    time: "13:00"
-  open-pull-requests-limit: 10


### PR DESCRIPTION
Since we aren't going to maintain this repository in the long term, `dependabot.yml` is not necessary.

